### PR TITLE
Stubs mixpanel if no token set.

### DIFF
--- a/source/client/mixpanel.js
+++ b/source/client/mixpanel.js
@@ -1,7 +1,16 @@
 /*global MIXPANEL_TOKEN*/
-
 import mixpanel from 'mixpanel-browser';
 
-mixpanel.init(MIXPANEL_TOKEN); // Token is defined in webpack.config
+let mix = mixpanel;
 
-export { mixpanel as default };
+if (MIXPANEL_TOKEN) {
+  mixpanel.init(MIXPANEL_TOKEN); // Token is defined in webpack.config
+} else {
+  let mixpanelStub = {};
+  mixpanelStub.identify = function() {};
+  mixpanelStub.track = function() {};
+
+  mix = mixpanelStub;
+}
+
+export { mix as default };


### PR DESCRIPTION
Currently if you don't have a valid mixpanel token set, click handlers will error and not allow you to do anything. This stubs mixpanel if no token is set.
